### PR TITLE
Update translation placeholders syntax

### DIFF
--- a/src/commands/namicomi/nami.js
+++ b/src/commands/namicomi/nami.js
@@ -185,7 +185,7 @@ module.exports = {
             const row = new ActionRowBuilder().addComponents(menu);
 
             embed.setTitle(translations.embed.query.title)
-                .setDescription(translations.embed.query.description.replace('%query%', query))
+                .setDescription(translations.embed.query.description.replace('{query}', query))
                 .addFields(fields)
                 .setColor(Colors.Blurple);
 

--- a/src/components/buttons/mangadex_stats.js
+++ b/src/components/buttons/mangadex_stats.js
@@ -68,7 +68,7 @@ module.exports = {
         // Create an embed with the statistics data
         const embed = new EmbedBuilder()
             .setTitle(translations.embed.title)
-            .setDescription(translations.embed.description.replace('%mangaId%', title))
+            .setDescription(translations.embed.description.replace('{mangaId}', title))
             .addFields(
                 { name: translations.embed.fields.average, value: `${averageRating}/10.00 (${totalVotes} ${translations.embed.units.votes})`, inline: true },
                 { name: translations.embed.fields.bayesian, value: `${bayesianRating}/10.00`, inline: true },

--- a/src/components/buttons/nami_stats.js
+++ b/src/components/buttons/nami_stats.js
@@ -57,7 +57,7 @@ module.exports = {
         // Create an embed with the rating and statistics data
         const embed = new EmbedBuilder()
             .setTitle(translations.embed.title)
-            .setDescription(translations.embed.description.replace('%titleId%', title))
+            .setDescription(translations.embed.description.replace('{titleId}', title))
             .addFields(
                 {
                     name: translations.embed.fields.rating,

--- a/src/functions/handlers/handleLocales.js
+++ b/src/functions/handlers/handleLocales.js
@@ -100,7 +100,7 @@ const translate = (locale, category, key, replacements = {}) => {
     if (!translation) return null;
 
     return Object.entries(replacements).reduce(
-        (translatedText, [placeholder, value]) => translatedText.replace(new RegExp(`%${placeholder}%`, 'g'), value),
+        (translatedText, [placeholder, value]) => translatedText.replace(new RegExp(`{${placeholder}}`, 'g'), value),
         translation
     );
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,24 +16,24 @@
                 "fields": {
                     "bot_latency": {
                         "name": "Bot Latency",
-                        "value": "%ping%ms"
+                        "value": "{ping}ms"
                     },
                     "api": {
                         "discord": {
                             "name": "Discord API",
-                            "value": "%apiPing%ms"
+                            "value": "{apiPing}ms"
                         },
                         "mangadex": {
                             "name": "MangaDex API",
-                            "value": "%mdPing%ms"
+                            "value": "{mdPing}ms"
                         },
                         "namicomi": {
                             "name": "NamiComi API",
-                            "value": "%ncPing%ms"
+                            "value": "{ncPing}ms"
                         }
                     }
                 },
-                "footer": "%commandName% - Requested by %user%",
+                "footer": "{commandName} - Requested by {user}",
                 "not_ok": "Fetch failed"
             }
         },
@@ -66,7 +66,7 @@
                         "value": "To view the bot's uptime, use `/uptime`."
                     }
                 },
-                "footer": "%commandName% - Requested by %user%"
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "commands": {
@@ -77,7 +77,7 @@
             "response": {
                 "title": "Commands",
                 "fields": {},
-                "footer": "%commandName% - Requested by %user%"
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "invite": {
@@ -87,8 +87,8 @@
             "options": {},
             "response": {
                 "title": "Invite",
-                "description": "You can invite the bot to your server by clicking [here](%inviteLink%).",
-                "footer": "%commandName% - Requested by %user%"
+                "description": "You can invite the bot to your server by clicking [here]({inviteLink}).",
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "stats": {
@@ -112,7 +112,7 @@
                         "name": "Uptime"
                     }
                 },
-                "footer": "%commandName% - Requested by %user%"
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "support": {
@@ -122,8 +122,8 @@
             "options": {},
             "response": {
                 "title": "Support",
-                "description": "You can join the bot's support server by clicking [here](%supportLink%).",
-                "footer": "%commandName% - Requested by %user%"
+                "description": "You can join the bot's support server by clicking [here]({supportLink}).",
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "uptime": {
@@ -133,8 +133,8 @@
             "options": {},
             "response": {
                 "title": "Uptime",
-                "description": "The bot has been online for %uptime%.",
-                "footer": "%commandName% - Requested by %user%"
+                "description": "The bot has been online for {uptime}.",
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "manga": {
@@ -225,13 +225,13 @@
                 },
                 "query": {
                     "title": "Search Results",
-                    "description": "Here are the search results for `%query%`.",
+                    "description": "Here are the search results for `{query}`.",
                     "fields": {},
                     "placeholder": "Select a manga to view more information..."
                 },
                 "stats": {
                     "title": "Manga Stats",
-                    "description": "Here are the stats for the manga with ID `%mangaId%`.",
+                    "description": "Here are the stats for the manga with ID `{mangaId}`.",
                     "fields": {
                         "average": {
                             "name": "Average Rating"
@@ -270,7 +270,7 @@
                         "empty": "Please provide either a query, ID, or URL."
                     }
                 },
-                "footer": "%commandName% - Requested by %user%"
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "nami": {
@@ -373,13 +373,13 @@
                 },
                 "query": {
                     "title": "Search Results",
-                    "description":"Here are the search results for `%query%`.",
+                    "description":"Here are the search results for `{query}`.",
                     "fields": {},
                     "placeholder": "Select a title to view more information."
                 },
                 "stats": {
                     "title": "Title Stats",
-                    "description": "Here are the stats for the title with ID `%titleId%`.",
+                    "description": "Here are the stats for the title with ID `{titleId}`.",
                     "fields": {
                         "rating": {
                             "name": "Rating"
@@ -416,11 +416,11 @@
                         "url": "The provided URL is invalid.",
                         "invalid_id": "The provided ID is invalid.",
                         "no_results": "The query returned no results. That's all we know.",
-                        "api": "An error occurred while fetching the title data.\nPlease try again later.\nStatus code: %statusCode%",
+                        "api": "An error occurred while fetching the title data.\nPlease try again later.\nStatus code: {statusCode}",
                         "empty": "Please provide either a query, ID, or URL."
                     }
                 },
-                "footer": "%commandName% - Requested by %user%"
+                "footer": "{commandName} - Requested by {user}"
             }
         },
         "settings": {
@@ -467,15 +467,15 @@
                                     }
                                 },
                                 "description": {
-                                    "success": "Your preferred language has been set to `%locale%`.",
+                                    "success": "Your preferred language has been set to `{locale}`.",
                                     "error": {
-                                        "invalid_locale": "The language `%locale%` is not valid.",
-                                        "no_changes": "No changes made. The language remains set to `%locale%`.",
+                                        "invalid_locale": "The language `{locale}` is not valid.",
+                                        "no_changes": "No changes made. The language remains set to `{locale}`.",
                                         "unknown": "An unknown error occurred while changing the language."
                                     }
                                 },
                                 "fields": {},
-                                "footer": "%commandName% - Requested by %user%"
+                                "footer": "{commandName} - Requested by {user}"
                             }
                         },
                         "reset": {
@@ -492,7 +492,7 @@
                                     "error": "An error occurred while resetting your preferred language."
                                 },
                                 "fields": {},
-                                "footer": "%commandName% - Requested by %user%"
+                                "footer": "{commandName} - Requested by {user}"
                             }
                         }
                     }
@@ -500,7 +500,7 @@
             },
             "options": {},
             "response": {
-                "footer": "%commandName% - Requested by %user%"
+                "footer": "{commandName} - Requested by {user}"
             }
         }
     },
@@ -510,12 +510,12 @@
         "message": "Error message",
         "stack": "Error stack trace",
         "no_stack": "No stack trace available",
-        "err_int_ch_input": "Error in command %commandName%",
-        "err_int_btn": "Error in button %buttonId%",
-        "err_int_slct": "Error in select menu %selectId%",
-        "err_int_ctx": "Error in context command %contextId%",
-        "err_int_mod": "Error in modal %modalId%",
-        "err_int_aut": "Error in autocomplete %autocompleteId%",
+        "err_int_ch_input": "Error in command {commandName}",
+        "err_int_btn": "Error in button {buttonId}",
+        "err_int_slct": "Error in select menu {selectId}",
+        "err_int_ctx": "Error in context command {contextId}",
+        "err_int_mod": "Error in modal {modalId}",
+        "err_int_aut": "Error in autocomplete {autocompleteId}",
         "timeout": {
             "title": "Timeout",
             "description": "A timeout occured while fetching data from an external API. Please try again later.",
@@ -532,7 +532,7 @@
                     "value": "We don't have an ETA for this command yet. Please be patient."
                 }
             ],
-            "footer": "%commandName% - Requested by %user%"
+            "footer": "{commandName} - Requested by {user}"
         }
     }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -16,24 +16,24 @@
                 "fields": {
                     "bot_latency": {
                         "name": "Latencia del Bot",
-                        "value": "%ping%ms"
+                        "value": "{ping}ms"
                     },
                     "api": {
                         "discord": {
                             "name": "API Discord",
-                            "value": "%apiPing%ms"
+                            "value": "{apiPing}ms"
                         },
                         "mangadex": {
                             "name": "API MangaDex",
-                            "value": "%mdPing%ms"
+                            "value": "{mdPing}ms"
                         },
                         "namicomi": {
                             "name": "API NamiComi",
-                            "value": "%ncPing%ms"
+                            "value": "{ncPing}ms"
                         }
                     }
                 },
-                "footer": "%commandName% - Solicitado por %user%",
+                "footer": "{commandName} - Solicitado por {user}",
                 "not_ok": "Error al obtener los datos"
             }
         },
@@ -66,7 +66,7 @@
                         "value": "Para ver el tiempo de actividad del bot, usa `/uptime`."
                     }
                 },
-                "footer": "%commandName% - Solicitado por %user%"
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "commands": {
@@ -77,7 +77,7 @@
             "response": {
                 "title": "Comandos",
                 "fields": {},
-                "footer": "%commandName% - Solicitado por %user%"
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "invite": {
@@ -87,8 +87,8 @@
             "options": [],
             "response": {
                 "title": "Invitar",
-                "description": "Puedes invitar al bot a tu servidor haciendo clic [aquí](%inviteLink%).",
-                "footer": "%commandName% - Solicitado por %user%"
+                "description": "Puedes invitar al bot a tu servidor haciendo clic [aquí]({inviteLink}).",
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "stats": {
@@ -112,7 +112,7 @@
                         "name": "Tiempo de actividad"
                     }
                 },
-                "footer": "%commandName% - Solicitado por %user%"
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "support": {
@@ -122,8 +122,8 @@
             "options": {},
             "response": {
                 "title": "Soporte",
-                "description": "Puedes unirte al servidor de soporte del bot haciendo clic [aquí](%supportLink%).",
-                "footer": "%commandName% - Solicitado por %user%"
+                "description": "Puedes unirte al servidor de soporte del bot haciendo clic [aquí]({supportLink}).",
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "uptime": {
@@ -133,8 +133,8 @@
             "options": [],
             "response": {
                 "title": "Tiempo de Actividad",
-                "description": "El bot ha estado en línea por %uptime%.",
-                "footer": "%commandName% - Solicitado por %user%"
+                "description": "El bot ha estado en línea por {uptime}.",
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "manga": {
@@ -225,13 +225,13 @@
                 },
                 "query": {
                     "title": "Resultados de la Búsqueda",
-                    "description": "Aquí están los resultados de la búsqueda para `%query%`.",
+                    "description": "Aquí están los resultados de la búsqueda para `{query}`.",
                     "fields": {},
                     "placeholder": "Selecciona un manga para ver más información..."
                 },
                 "stats": {
                     "title": "Estadísticas del Manga",
-                    "description": "Aquí están las estadísticas para el manga con ID `%mangaId%`.",
+                    "description": "Aquí están las estadísticas para el manga con ID `{mangaId}`.",
                     "fields": {
                         "average": {
                             "name": "Valoración Media"
@@ -270,7 +270,7 @@
                         "empty": "Por favor, proporciona una consulta, ID o URL."
                     }
                 },
-                "footer": "%commandName% - Solicitado por %user%"
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "nami": {
@@ -373,13 +373,13 @@
                 },
                 "query": {
                     "title": "Resultados de la Búsqueda",
-                    "description": "Aquí están los resultados de la búsqueda para `%query%`.",
+                    "description": "Aquí están los resultados de la búsqueda para `{query}`.",
                     "fields": {},
                     "placeholder": "Selecciona un título para ver más información..."
                 },
                 "stats": {
                     "title": "Estadísticas del Título",
-                    "description": "Aquí están las estadísticas para el título con ID `%titleId%`.",
+                    "description": "Aquí están las estadísticas para el título con ID `{titleId}`.",
                     "fields": {
                         "rating": {
                             "name": "Valoraciones"
@@ -416,11 +416,11 @@
                         "url": "La URL proporcionada no es válida.",
                         "invalid_id": "La ID proporcionada no es válida.",
                         "no_results": "La consulta no devolvió resultados. Es todo lo que sabemos.",
-                        "api": "Ha ocurrido un error al obtener los datos del título.\nPor favor, inténtalo de nuevo más tarde.\nCódigo de estado: %statusCode%",
+                        "api": "Ha ocurrido un error al obtener los datos del título.\nPor favor, inténtalo de nuevo más tarde.\nCódigo de estado: {statusCode}",
                         "empty": "Por favor, proporciona una consulta, ID o URL."
                     }
                 },
-                "footer": "%commandName% - Solicitado por %user%"
+                "footer": "{commandName} - Solicitado por {user}"
             }
         },
         "settings": {
@@ -467,15 +467,15 @@
                                     }
                                 },
                                 "description": {
-                                    "success": "El idioma ha sido cambiado a `%locale%`.",
+                                    "success": "El idioma ha sido cambiado a `{locale}`.",
                                     "error": {
-                                        "invalid_locale": "El idioma `%locale%` no es válido.",
-                                        "no_changes": "No se realizaron cambios. El idioma establecido sigue siendo `%locale%`.",
+                                        "invalid_locale": "El idioma `{locale}` no es válido.",
+                                        "no_changes": "No se realizaron cambios. El idioma establecido sigue siendo `{locale}`.",
                                         "unknown": "Ha ocurrido un error desconocido al cambiar el idioma."
                                     }
                                 },
                                 "fields": {},
-                                "footer": "%commandName% - Solicitado por %user%"
+                                "footer": "{commandName} - Solicitado por {user}"
                             }
                         },
                         "reset": {
@@ -492,7 +492,7 @@
                                     "error": "Ha ocurrido un error al restablecer el idioma."
                                 },
                                 "fields": {},
-                                "footer": "%commandName% - Solicitado por %user%"
+                                "footer": "{commandName} - Solicitado por {user}"
                             }
                         }
                     }
@@ -500,7 +500,7 @@
             },
             "options": {},
             "response": {
-                "footer": "%commandName% - Solicitado por %user%"
+                "footer": "{commandName} - Solicitado por {user}"
             }
         }
     },
@@ -510,12 +510,12 @@
         "message": "Mensaje de error",
         "stack": "Pila del error",
         "no_stack": "No se ha proporcionado una pila de error.",
-        "err_int_ch_input": "Error en el comando %commandName%",
-        "err_int_btn": "Error en el botón %buttonId%",
-        "err_int_slct": "Error en el menú de selección %selectId%",
-        "err_int_ctx": "Error en el comando de contexto %contextId%",
-        "err_int_mod": "Error en el modal %modalId%",
-        "err_int_aut": "Error en la autocompletación %autocompleteId%",
+        "err_int_ch_input": "Error en el comando {commandName}",
+        "err_int_btn": "Error en el botón {buttonId}",
+        "err_int_slct": "Error en el menú de selección {selectId}",
+        "err_int_ctx": "Error en el comando de contexto {contextId}",
+        "err_int_mod": "Error en el modal {modalId}",
+        "err_int_aut": "Error en la autocompletación {autocompleteId}",
         "timeout": {
             "title": "Timeout",
             "description": "Se ha agotado el tiempo de espera al obtener los datos desde la API externa. Por favor, inténtalo de nuevo más tarde.",
@@ -532,7 +532,7 @@
                     "value": "No hay una fecha de lanzamiento prevista en este momento. Por favor, sé paciente."
                 }
             ],
-            "footer": "%commandName% - Solicitado por %user%"
+            "footer": "{commandName} - Solicitado por {user}"
         }
     }
 }

--- a/tests/commands/configuration/settings.test.js
+++ b/tests/commands/configuration/settings.test.js
@@ -107,7 +107,7 @@ describe('settings command', () => {
                         case 'settings.subcommand_groups.locale.subcommands.set.response.title.success':
                             return 'Language Set';
                         case 'settings.subcommand_groups.locale.subcommands.set.response.description.success':
-                            return 'Your preferred language has been set to `%locale%`.'.replace('%locale%', 'es');
+                            return 'Your preferred language has been set to `{locale}`.'.replace('{locale}', 'es');
                         case 'settings.response.footer':
                             return '/settings - Requested by test-user';
                         default:
@@ -216,7 +216,7 @@ describe('settings command', () => {
                         case 'settings.subcommand_groups.locale.subcommands.set.response.title.error.invalid_locale':
                             return 'Invalid Language';
                         case 'settings.subcommand_groups.locale.subcommands.set.response.description.error.invalid_locale':
-                            return 'The language `%locale%` is not valid.'.replace('%locale%', 'xx');
+                            return 'The language `{locale}` is not valid.'.replace('{locale}', 'xx');
                         case 'settings.response.footer':
                             return '/settings - Requested by test-user';
                         default:
@@ -315,7 +315,7 @@ describe('settings command', () => {
                         case 'settings.subcommand_groups.locale.subcommands.set.response.title.success':
                             return 'Language Set';
                         case 'settings.subcommand_groups.locale.subcommands.set.response.description.success':
-                            return 'Your preferred language has been set to `%locale%`.'.replace('%locale%', 'es');
+                            return 'Your preferred language has been set to `{locale}`.'.replace('{locale}', 'es');
                         case 'settings.response.footer':
                             return '/settings - Requested by test-user';
                         default:
@@ -458,7 +458,7 @@ describe('settings command', () => {
                         case 'settings.subcommand_groups.locale.subcommands.set.response.title.error.invalid_locale':
                             return 'Invalid Language';
                         case 'settings.subcommand_groups.locale.subcommands.set.response.description.error.invalid_locale':
-                            return 'The language `%locale%` is not valid.'.replace('%locale%', 'xx');
+                            return 'The language `{locale}` is not valid.'.replace('{locale}', 'xx');
                         case 'settings.response.footer':
                             return '/settings - Requested by test-user';
                         default:
@@ -602,7 +602,7 @@ describe('settings command', () => {
                         case 'settings.subcommand_groups.locale.subcommands.set.response.title.error.no_changes':
                             return 'No Changes';
                         case 'settings.subcommand_groups.locale.subcommands.set.response.description.error.no_changes':
-                            return 'No changes made. The language remains set to `%locale%`.'.replace('%locale%', 'en');
+                            return 'No changes made. The language remains set to `{locale}`.'.replace('{locale}', 'en');
                         case 'settings.response.footer':
                             return '/settings - Requested by test-user';
                         default:

--- a/tests/functions/handlers/handleLocales.test.js
+++ b/tests/functions/handlers/handleLocales.test.js
@@ -130,7 +130,7 @@ describe('handleLocales', () => {
             path.join.mockImplementation((...args) => args.join('/'));
             fs.readdirSync.mockReturnValue(['en.json']);
             fs.readFileSync.mockImplementation((filePath, encoding) => {
-                return JSON.stringify({ commands: { testCommand: { description: '%test% Description3' } }  });
+                return JSON.stringify({ commands: { testCommand: { description: '{test} Description3' } }  });
             });
 
             await client.handleLocales();


### PR DESCRIPTION
Replace percent signs with curly braces for placeholder formatting in translation strings.
Ensures consistent placeholder replacement across components, locales, and tests.
