### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: SonarCloud
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Bartolumiu/dexchan/security/code-scanning/8](https://github.com/Bartolumiu/dexchan/security/code-scanning/8)

To fix the problem, add a `permissions` key to the workflow file. The best practice is to set this at the workflow level (top-level, just after the `name` and before `on`), so it applies to all jobs unless overridden. The minimal required permission for most workflows that only need to read repository contents is `contents: read`. If the SonarCloud action or other steps require additional permissions (such as updating PR statuses), those can be added as needed, but the starting point should be the minimal set. In this case, add:

```yaml
permissions:
  contents: read
```

immediately after the `name: SonarCloud` line (line 1). No other changes are required unless the workflow fails due to insufficient permissions, in which case the required permissions can be incrementally added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
